### PR TITLE
Sso token login

### DIFF
--- a/MoquiConf.xml
+++ b/MoquiConf.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!-- No copyright or license for configuration file, details here are not considered a creative work. -->
 <moqui-conf xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://moqui.org/xsd/moqui-conf-3.xsd">
+    <tools>
+        <tool-factory class="org.moqui.sso.MoquiSsoToolFactory" init-priority="30" disabled="false"/>
+    </tools>
+    <user-facade sso-access-token-handler-factory="MoquiSso"/>
     <screen-facade>
         <screen location="component://webroot/screen/webroot.xml">
             <subscreens-item name="sso" location="component://moqui-sso/screen/sso.xml"/>

--- a/screen-extend/webroot/Login.xml
+++ b/screen-extend/webroot/Login.xml
@@ -36,13 +36,15 @@ along with this software (see the LICENSE.md file). If not, see
     </transition>
 
     <actions-extend>
-        <script>ec.artifactExecution.disableAuthz()</script>
+        <set field="alreadyDisabled" from="ec.artifactExecution.disableAuthz()"/>
         <entity-find entity-name="moqui.security.sso.AuthFlow" list="authFlowList">
             <econdition field-name="inbound" operator="not-equals" value="Y" or-null="true"/>
             <econdition field-name="disabled" operator="not-equals" value="Y" or-null="true"/>
             <order-by field-name="sequenceNum"/>
         </entity-find>
-        <script>ec.artifactExecution.enableAuthz()</script>
+        <if condition="!alreadyDisabled">
+            <script>ec.artifactExecution.enableAuthz()</script>
+        </if>
     </actions-extend>
     
 </screen-extend>

--- a/src/main/groovy/org/moqui/sso/AuthenticationClientFactory.groovy
+++ b/src/main/groovy/org/moqui/sso/AuthenticationClientFactory.groovy
@@ -43,6 +43,8 @@ final class AuthenticationClientFactory {
                 .condition("authFlowId", authFlowId)
                 .one()
 
+        if (authFlow == null)
+            return null
         // build client
         if ("AftOidc" == authFlow.authFlowTypeEnumId) {
             return buildOidcClient(authFlowId)

--- a/src/main/groovy/org/moqui/sso/AuthenticationFlow.groovy
+++ b/src/main/groovy/org/moqui/sso/AuthenticationFlow.groovy
@@ -194,9 +194,10 @@ class AuthenticationFlow {
             }
         } catch (RuntimeException e) {
             ec.logger.error("An error occurred while handling SWT login", e)
+        } finally {
+            if (!alreadyDisabled)
+                ec.artifactExecution.enableAuthz()
         }
-        if (!alreadyDisabled)
-            ec.artifactExecution.enableAuthz()
         return false
     }
 }

--- a/src/main/groovy/org/moqui/sso/AuthenticationFlow.groovy
+++ b/src/main/groovy/org/moqui/sso/AuthenticationFlow.groovy
@@ -4,7 +4,9 @@ import org.moqui.context.ExecutionContext
 import org.moqui.impl.context.UserFacadeImpl
 import org.pac4j.core.authorization.authorizer.DefaultAuthorizers
 import org.pac4j.core.client.Client
+import org.pac4j.core.client.IndirectClient
 import org.pac4j.core.config.Config
+import org.pac4j.core.credentials.TokenCredentials
 import org.pac4j.core.engine.DefaultCallbackLogic
 import org.pac4j.core.engine.DefaultLogoutLogic
 import org.pac4j.core.engine.DefaultSecurityLogic
@@ -150,5 +152,51 @@ class AuthenticationFlow {
             ec.logger.error("An error occurred while performing logout action", e)
             ec.web.response.sendRedirect(returnTo ?: baseUrl + "/Login")
         }
+    }
+
+    static boolean handleSwtLogin(ExecutionContext ec, String ssoAccessToken, String ssoAuthFlowId) {
+        // init fields required for logic
+        JEEContext context = new JEEContext(ec.web.request, ec.web.response)
+        JEESessionStore sessionStore = JEESessionStore.INSTANCE
+        org.moqui.sso.MoquiSecurityGrantedAccessAdapter securityGrantedAccessAdapter = new org.moqui.sso.MoquiSecurityGrantedAccessAdapter(ec)
+        JEEHttpActionAdapter actionAdapter = JEEHttpActionAdapter.INSTANCE
+
+        boolean alreadyDisabled = ec.artifactExecution.disableAuthz()
+        // init config
+        String baseUrl = ec.web.getWebappRootUrl(true, false)
+        Client client = null
+        if (ssoAuthFlowId) {
+            client = new org.moqui.sso.AuthenticationClientFactory(ec).build(ssoAuthFlowId)
+            if (client == null)
+                ec.message.addError("Did not find specified ssoAuthFlowId '${ssoAuthFlowId}'")
+        } else {
+            List clientList = new org.moqui.sso.AuthenticationClientFactory(ec).buildAll()
+            if (clientList)
+                client = clientList.get(0)
+            else
+                ec.message.addError("No AuthFlow found!")
+        }
+        if (client instanceof IndirectClient)
+            ((IndirectClient)client).setCallbackUrl(baseUrl + "/sso/callback")
+
+        TokenCredentials tokenCredentials = new TokenCredentials(ssoAccessToken)
+        UserProfile userProfile = client.getUserProfile(tokenCredentials, context, sessionStore).get()
+
+        try {
+            // handle incoming profiles
+            securityGrantedAccessAdapter.adapt(context, sessionStore, [userProfile])
+
+            // login user
+            if (userProfile.username) {
+                ((UserFacadeImpl) ec.user).internalLoginUser(userProfile.username)
+                ec.web.sessionAttributes.put("moquiAuthFlowExternalLogout", true)
+                return true
+            }
+        } catch (RuntimeException e) {
+            ec.logger.error("An error occurred while handling SWT login", e)
+        }
+        if (!alreadyDisabled)
+            ec.artifactExecution.enableAuthz()
+        return false
     }
 }

--- a/src/main/groovy/org/moqui/sso/MoquiSsoToolFactory.groovy
+++ b/src/main/groovy/org/moqui/sso/MoquiSsoToolFactory.groovy
@@ -7,6 +7,9 @@ import org.moqui.security.SingleSignOnTokenLoginHandler
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
 class MoquiSsoToolFactory implements ToolFactory<SingleSignOnTokenLoginHandler>{
     protected final static Logger logger = LoggerFactory.getLogger(MoquiSsoToolFactory.class)
     final static String TOOL_NAME = "MoquiSso"
@@ -36,8 +39,8 @@ class MoquiSsoToolFactory implements ToolFactory<SingleSignOnTokenLoginHandler>{
 
     class SsoTokenLoginHandler implements SingleSignOnTokenLoginHandler {
         @Override
-        boolean handleSsoLoginToken(ExecutionContext ec, String ssoAccessToken, String ssoAuthFlowId) {
-            return AuthenticationFlow.handleSwtLogin(ec, ssoAccessToken, ssoAuthFlowId)
+        boolean handleSsoLoginToken(ExecutionContext ec, HttpServletRequest request, HttpServletResponse response, String ssoAccessToken, String ssoAuthFlowId) {
+            return AuthenticationFlow.handleSwtLogin(ec, request, response, ssoAccessToken, ssoAuthFlowId)
         }
     }
 }

--- a/src/main/groovy/org/moqui/sso/MoquiSsoToolFactory.groovy
+++ b/src/main/groovy/org/moqui/sso/MoquiSsoToolFactory.groovy
@@ -1,0 +1,43 @@
+package org.moqui.sso
+
+import org.moqui.context.ExecutionContext
+import org.moqui.context.ExecutionContextFactory
+import org.moqui.context.ToolFactory
+import org.moqui.security.SingleSignOnTokenLoginHandler
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+class MoquiSsoToolFactory implements ToolFactory<SingleSignOnTokenLoginHandler>{
+    protected final static Logger logger = LoggerFactory.getLogger(MoquiSsoToolFactory.class)
+    final static String TOOL_NAME = "MoquiSso"
+
+    protected ExecutionContextFactory ecf = null
+
+    protected SingleSignOnTokenLoginHandler ssoTokenLoginHandler = null
+
+    @Override
+    String getName() { return TOOL_NAME }
+    @Override
+    void init(ExecutionContextFactory ecf) { }
+    @Override
+    void preFacadeInit(ExecutionContextFactory ecf) { }
+    @Override
+    SingleSignOnTokenLoginHandler getInstance(Object... parameters) {
+        if (ssoTokenLoginHandler == null)
+            ssoTokenLoginHandler = new SsoTokenLoginHandler()
+        return ssoTokenLoginHandler
+    }
+
+    @Override
+    void destroy() { }
+
+    @Override
+    void postFacadeDestroy() { }
+
+    class SsoTokenLoginHandler implements SingleSignOnTokenLoginHandler {
+        @Override
+        boolean handleSsoLoginToken(ExecutionContext ec, String ssoAccessToken, String ssoAuthFlowId) {
+            return AuthenticationFlow.handleSwtLogin(ec, ssoAccessToken, ssoAuthFlowId)
+        }
+    }
+}


### PR DESCRIPTION
Add capability to log into the system by using a login_token issued by a known identity provider (like Keycloak or another OpenId capable system), fetching user data from identity provider as specified by the registered mappings. Requires changes in Framework (https://github.com/moqui/moqui-framework/pull/638).